### PR TITLE
Handle normalizing a 0-length vector.

### DIFF
--- a/SwiftVector/SwiftVector/vec2.swift
+++ b/SwiftVector/SwiftVector/vec2.swift
@@ -14,6 +14,12 @@ public struct vec2: Equatable, Printable {
   public let x: Double
   public let y: Double
 
+  // For purposes of comparisons and scaling operations, any magnitude less than this value is
+  // considered to be 0. Note: it's not a good idea to use this value directly when comparing
+  // (e.g. fabs(a - b) < EPSILON). See http://www.cygnus-software.com/papers/comparingfloats/comparingfloats.htm
+  // for more info.
+  internal let EPSILON = 1.0e-14;
+
   public var asCGVector: CGVector {
     get {
       return CGVector(dx: x, dy: y)
@@ -91,7 +97,11 @@ public struct vec2: Equatable, Printable {
   /// :return: A normalized vector
   public func normalize() -> vec2 {
     let m = self.length;
-    return scale(1/m);
+    if m < EPSILON {
+      return vec2(0.0, 0.0);
+    } else {
+      return scale(1/m);
+    }
   }
 }
 

--- a/SwiftVector/SwiftVectorTests/vec2Tests.swift
+++ b/SwiftVector/SwiftVectorTests/vec2Tests.swift
@@ -71,4 +71,11 @@ class vec2Tests: XCTestCase {
     XCTAssertEqualWithAccuracy(v2.length, 1.0, epsilon)
     XCTAssertEqualWithAccuracy(v1.angle, v2.angle, epsilon)
   }
+
+  func testNormalizeZero() {
+    let v1 = vec2(0, 0)
+    let v2 = v1.normalize()
+    XCTAssertEqualWithAccuracy(v2.length, 0.0, epsilon)
+    XCTAssertEqualWithAccuracy(v1.angle, v2.angle, epsilon)
+  }
 }


### PR DESCRIPTION
Normalizing a 0-length vector should return another 0-length vector.

Tests updated.
